### PR TITLE
Update AFNetworking-RACExtensions.podspec

### DIFF
--- a/AFNetworking-RACExtensions.podspec
+++ b/AFNetworking-RACExtensions.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "AFNetworking-RACExtensions"
-  s.version      = "0.1.3"
+  s.version      = "0.1.6"
   s.summary      = "AFNetworking-RACExtensions is a delightful extension to the AFNetworking classes for iOS and Mac OS X."
   s.homepage     = "https://github.com/CodaFi/AFNetworking-RACExtensions"
   s.license      = { :type => 'MIT', :file => 'LICENSE' }


### PR DESCRIPTION
Since latest tag is `0.1.6`, we should update version to `0.1.6` as well.
