### PR TITLE
Send headers

### DIFF
--- a/RACAFNetworking/AFHTTPRequestOperationManager+RACSupport.h
+++ b/RACAFNetworking/AFHTTPRequestOperationManager+RACSupport.h
@@ -50,23 +50,23 @@ extern NSString *const RAFNetworkingOperationErrorKey;
 - (RACSignal *)rac_enqueueHTTPRequestOperation:(AFHTTPRequestOperation *)requestOperation;
 
 /// A convenience around -GET:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_GET:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -POST:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_POST:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -PUT:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_PUT:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -DELETE:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_DELETE:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -PATCH:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_PATCH:(NSString *)path parameters:(id)parameters;
 
 @end

--- a/RACAFNetworking/AFHTTPSessionManager+RACSupport.h
+++ b/RACAFNetworking/AFHTTPSessionManager+RACSupport.h
@@ -14,11 +14,11 @@
 @interface AFHTTPSessionManager (RACSupport)
 
 /// A convenience around -GET:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_GET:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -HEAD:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_HEAD:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -POST:parameters:success:failure: that returns a cold signal of the
@@ -26,19 +26,19 @@
 - (RACSignal *)rac_POST:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -POST:parameters:constructingBodyWithBlock:success:failure: that returns a
-/// cold signal of the resulting JSON object or error.
+/// cold signal of the resulting JSON object and response headers or error.
 - (RACSignal *)rac_POST:(NSString *)path parameters:(id)parameters constructingBodyWithBlock:(void (^)(id <AFMultipartFormData> formData))block;
 
 /// A convenience around -PUT:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_PUT:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -PATCH:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_PATCH:(NSString *)path parameters:(id)parameters;
 
 /// A convenience around -DELETE:parameters:success:failure: that returns a cold signal of the
-/// resulting JSON object or error.
+/// resulting JSON object and response headers or error.
 - (RACSignal *)rac_DELETE:(NSString *)path parameters:(id)parameters;
 
 @end

--- a/RACAFNetworking/AFURLConnectionOperation+RACSupport.m
+++ b/RACAFNetworking/AFURLConnectionOperation+RACSupport.m
@@ -25,8 +25,8 @@
 #ifdef RAFN_MAINTAIN_COMPLETION_BLOCKS
 		void (^oldCompBlock)() = self.completionBlock;
 #endif
-		[(AFHTTPRequestOperation*)self setCompletionBlockWithSuccess:^(id operation, id responseObject) {
-			[subject sendNext:responseObject];
+		[(AFHTTPRequestOperation *)self setCompletionBlockWithSuccess:^(AFHTTPRequestOperation *operation, id responseObject) {
+			[subject sendNext:RACTuplePack(responseObject, operation.response)];
 			[subject sendCompleted];
 #ifdef RAFN_MAINTAIN_COMPLETION_BLOCKS
 			if (oldCompBlock) {

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ initWithBaseURL:url];
 manager.requestSerializer = [AFJSONRequestSerializer serializer];
 manager.responseSerializer = [AFJSONResponseSerializer serializer];
 
-[[manager rac_GET:path parameters:params] subscribeNext:^(id JSON) {
-    //Voila, magical JSON…
+[[manager rac_GET:path parameters:params] subscribeNext:^(RACTuple *JSONAndHeaders) {
+    //Voila, a tuple with (JSON, HTTPResponse)
 }];
 ```
 


### PR DESCRIPTION
A quick fix for #25.  Interestingly enough it restores the original semantics of the signal.  I'm not sure when this got changed.
