### PR TITLE
Use <global> includes for AFNetworking classes

### DIFF
--- a/RACAFNetworking.xcodeproj/project.pbxproj
+++ b/RACAFNetworking.xcodeproj/project.pbxproj
@@ -1187,6 +1187,10 @@
 				);
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "RACAFNetworking/RACAFNetworking-Prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					External/AFNetworking,
+				);
 				INFOPLIST_FILE = RACAFNetworking/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
@@ -1212,6 +1216,10 @@
 				);
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "RACAFNetworking/RACAFNetworking-Prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					External/AFNetworking,
+				);
 				INFOPLIST_FILE = RACAFNetworking/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";

--- a/RACAFNetworking.xcodeproj/project.pbxproj
+++ b/RACAFNetworking.xcodeproj/project.pbxproj
@@ -1123,6 +1123,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/External/AFNetworking",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1162,6 +1166,10 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(SRCROOT)/External/AFNetworking",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 10.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
@@ -1187,10 +1195,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "RACAFNetworking/RACAFNetworking-Prefix.pch";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					External/AFNetworking,
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RACAFNetworking/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
@@ -1216,10 +1221,7 @@
 				);
 				FRAMEWORK_VERSION = A;
 				GCC_PREFIX_HEADER = "RACAFNetworking/RACAFNetworking-Prefix.pch";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					External/AFNetworking,
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = RACAFNetworking/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
@@ -1248,7 +1250,6 @@
 				);
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode6-Beta3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/External/Expecta/src\"",
 					"\"$(SRCROOT)/External/Specta/src\"",
 				);
@@ -1274,7 +1275,6 @@
 				GCC_PREFIX_HEADER = "RACAFNetworkingTests/RACAFNetworkingTests-Prefix.pch";
 				HEADER_SEARCH_PATHS = (
 					"$(inherited)",
-					"/Applications/Xcode6-Beta3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
 					"\"$(SRCROOT)/External/Expecta/src\"",
 					"\"$(SRCROOT)/External/Specta/src\"",
 				);
@@ -1296,6 +1296,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1308,6 +1309,7 @@
 				EXECUTABLE_PREFIX = lib;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREFIX_HEADER = "RACAFNetworking/RACAFNetworking-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -1323,10 +1325,7 @@
 					"DEBUG=1",
 					"$(inherited)",
 				);
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"/Applications/Xcode6-Beta3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -1343,10 +1342,7 @@
 				ALWAYS_SEARCH_USER_PATHS = YES;
 				FRAMEWORK_SEARCH_PATHS = "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 				GCC_PREFIX_HEADER = "RACAFNetworking/RACAFNetworking-Prefix.pch";
-				HEADER_SEARCH_PATHS = (
-					"$(inherited)",
-					"/Applications/Xcode6-Beta3.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include",
-				);
+				HEADER_SEARCH_PATHS = "$(inherited)";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/RACAFNetworking/AFHTTPRequestOperationManager+RACSupport.h
+++ b/RACAFNetworking/AFHTTPRequestOperationManager+RACSupport.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 CodaFi. All rights reserved.
 //
 
-#import "AFHTTPRequestOperationManager.h"
+#import <AFNetworking/AFHTTPRequestOperationManager.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 /// User info key for accessing the AFHTTPRequestOperation on which the error occured.

--- a/RACAFNetworking/AFHTTPSessionManager+RACSupport.h
+++ b/RACAFNetworking/AFHTTPSessionManager+RACSupport.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2014 CodaFi. All rights reserved.
 //
 
-#import "AFHTTPSessionManager.h"
+#import <AFNetworking/AFHTTPSessionManager.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 #if (defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 70000) || (defined(__MAC_OS_X_VERSION_MAX_ALLOWED) && __MAC_OS_X_VERSION_MAX_ALLOWED >= 1090)

--- a/RACAFNetworking/AFURLConnectionOperation+RACSupport.h
+++ b/RACAFNetworking/AFURLConnectionOperation+RACSupport.h
@@ -6,7 +6,7 @@
 //  Copyright (c) 2013 CodaFi. All rights reserved.
 //
 
-#import "AFHTTPRequestOperation.h"
+#import <AFNetworking/AFHTTPRequestOperation.h>
 #import <ReactiveCocoa/ReactiveCocoa.h>
 
 @interface AFHTTPRequestOperation (RACSupport)


### PR DESCRIPTION
So pod can be build as [dynamic framework](http://blog.cocoapods.org/CocoaPods-0.36/)

When using cocoapods `use_submodules!` option, I get following error messages after trying to build my app:

    Pods/AFNetworking-RACExtensions/RACAFNetworking/AFHTTPRequestOperationManager+RACSupport.h:9:9: 'AFHTTPRequestOperationManager.h' file not found
    ...
    MyApp/Code/API/API.swift:12:8: Could not build Objective-C module 'AFNetworking_RACExtensions'

To fix this `AFNetworking-RACExtensions` needs to use global includes (`#import <some/header.h>`) because AFNetworking headers are not in scope of the framework's public headers.