### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-##Announcement
+## Announcement
 
 Because I can no longer maintain this framework at the standards the open source community expects of me, and those I expect of myself, I have placed a feature freeze on this fork and will stop maintenance.  If support for future RAC's and AFNetworking's is needed, please fork this repository and update the podspecs as needed.
 
-##AFNetworking-RACExtensions
+## AFNetworking-RACExtensions
 
 [![Build Status](https://travis-ci.org/CodaFi/AFNetworking-RACExtensions.svg?branch=master)](https://travis-ci.org/CodaFi/AFNetworking-RACExtensions)
 
@@ -14,7 +14,7 @@ powerful high-level networking abstractions built into AFNetorking by lifting
 them into the Reactive world.  It has a modular architecture with well-designed,
 feature-rich APIs that are a joy to use.
 
-##Getting Started
+## Getting Started
 
 Request signals work in much the same way you would expect them to.  Any request
 that is subscribed to is automatically enqueued and the results, be they errors
@@ -31,16 +31,16 @@ manager.responseSerializer = [AFJSONResponseSerializer serializer];
 }];
 ```
 
-##Requirements
+## Requirements
 
 AFNetworking 1.0 and higher requires either [iOS 5.0](http://developer.apple.com/library/ios/#releasenotes/General/WhatsNewIniPhoneOS/Articles/iPhoneOS4.html) and above, or [Mac OS 10.8](http://developer.apple.com/library/mac/#releasenotes/MacOSX/WhatsNewInOSX/Articles/MacOSX10_6.html#//apple_ref/doc/uid/TP40008898-SW7) ([64-bit with modern Cocoa runtime](https://developer.apple.com/library/mac/#documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtVersionsPlatforms.html)) and above.
 
-##Contact
+## Contact
 
 [Robert Widmann](https://github.com/CodaFi)  
 [@CodaFi_](https://twitter.com/CodaFi_)
 
-##License
+## License
 
 AFNetworking+RACExtensions is available free of change under the Open Source license, along with the MIT license that AFNetworking uses.  Use it at your own risk.
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
